### PR TITLE
Update lm_eval usage and add NVFP4 dynamic quantization

### DIFF
--- a/quantize/int_linear.py
+++ b/quantize/int_linear.py
@@ -1,9 +1,12 @@
+import os
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from typing import Union
-from quantize.quantizer import UniformAffineQuantizer
+
 import numpy as np
+from quantize.nvfp4 import quant_nvfp4
+from quantize.quantizer import UniformAffineQuantizer
 
 
 class QuantLinear(nn.Module):
@@ -71,8 +74,10 @@ class QuantLinear(nn.Module):
             bias = self.bias
 
         if self.use_act_quant and not self.disable_input_quant:
-
-            input = self.act_quantizer(input)
+            if os.environ.get("NVFP4_ENABLE") == "1":
+                input = quant_nvfp4(input)
+            else:
+                input = self.act_quantizer(input)
             if self.record_quant_input:
                 # for debug
                 self.recorded_quant_input = input

--- a/quantize/int_matmul.py
+++ b/quantize/int_matmul.py
@@ -1,7 +1,10 @@
+import os
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from typing import Union
+
+from quantize.nvfp4 import quant_nvfp4
 from quantize.quantizer import UniformAffineQuantizer
 
 
@@ -40,12 +43,18 @@ class QuantMatMul(nn.Module):
 
     def quant_x1(self, x1):
         if self.use_act_quant:
-            x1 = self.x1_quantizer(x1)
+            if os.environ.get("NVFP4_ENABLE") == "1":
+                x1 = quant_nvfp4(x1)
+            else:
+                x1 = self.x1_quantizer(x1)
         return x1
 
     def quant_x2(self, x2):
         if self.use_act_quant:
-            x2 = self.x2_quantizer(x2)
+            if os.environ.get("NVFP4_ENABLE") == "1":
+                x2 = quant_nvfp4(x2)
+            else:
+                x2 = self.x2_quantizer(x2)
         return x2
 
     def forward(self, x1, x2):

--- a/quantize/nvfp4.py
+++ b/quantize/nvfp4.py
@@ -1,0 +1,58 @@
+import os
+import torch
+
+FP8_E4M3_MAX = 448.0
+
+
+def fp4_121_positive(x: torch.Tensor, stochastic_rounding: bool = False) -> torch.Tensor:
+    if stochastic_rounding:
+        noise = torch.rand_like(x) - 0.5
+        step1 = torch.round(2.0 * x + noise) / 2.0
+        step2 = torch.round(x + noise)
+        step3 = 2.0 * torch.round(x / 2.0 + noise)
+    else:
+        step1 = torch.round(2.0 * x) / 2.0
+        step2 = torch.round(x)
+        step3 = 2.0 * torch.round(x / 2.0)
+
+    mask1 = x < 2.0
+    mask2 = x < 4.0
+
+    return step1 * mask1 + step2 * (~mask1) * mask2 + step3 * (~mask1) * (~mask2)
+
+
+def quant_nvfp4(
+    x: torch.Tensor,
+    stochastic_rounding: bool = False,
+    batch_size: int = 1,
+    vari_length: bool = False,
+) -> torch.Tensor:
+    quant_mode = os.environ.get("QUANT_MODE", "")
+    fp4_121_max = 6.0
+    ori_shape = x.shape
+    x = x.reshape(-1, 16)
+    sign = x.sign()
+    x_abs = x.abs()
+    nvfp4_max = fp4_121_max * FP8_E4M3_MAX
+    scale_per_t = x_abs.max() / nvfp4_max
+    if quant_mode in ["Dynamic_Block", "Calib_Block"]:
+        scale_per_t = torch.tensor(1.0, device=x.device, dtype=x.dtype)
+    x_abs_scaled = x_abs / scale_per_t
+
+    if batch_size == 1:
+        scale_per_b = x_abs_scaled.max(dim=-1, keepdim=True)[0]
+    else:
+        scale_per_b = x_abs_scaled.max(dim=-1, keepdim=True)[0]
+
+    input_tensor = fp4_121_max / scale_per_b
+    down_cast = input_tensor.to(torch.float8_e4m3fn)
+    up_cast = down_cast.to(scale_per_b.dtype)
+    scale_per_b = torch.where(
+        (0 < up_cast) & (up_cast < torch.inf),
+        up_cast,
+        torch.tensor(1.0, device=scale_per_b.device, dtype=scale_per_b.dtype),
+    )
+
+    x_fp4_abs = fp4_121_positive(x_abs_scaled * scale_per_b, stochastic_rounding) / scale_per_b
+
+    return (sign * x_fp4_abs * scale_per_t).reshape(ori_shape)


### PR DESCRIPTION
## Summary
- adapt lm_evaluation script for lm_eval>=0.4.8 by dynamically retrieving available tasks
- add NVFP4 dynamic quantization utilities and integrate into quantized layers

## Testing
- `python -m py_compile lm_evaluation/main.py quantize/nvfp4.py quantize/int_linear.py quantize/int_matmul.py quantize/reorder_layer_norm.py quantize/quant_transformer_layer.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sacrebleu'; numpy; etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c645241a60833286870c5eafe20f9b