### PR TITLE
Allow loading LLaMA from local path

### DIFF
--- a/main.py
+++ b/main.py
@@ -196,6 +196,12 @@ def main():
     parser.add_argument("--load", type=str, default="")
     parser.add_argument("--disable_w_quant", action="store_true")
     parser.add_argument("--disable_a_quant", action="store_true")
+    parser.add_argument(
+        "--model_path",
+        type=str,
+        default=None,
+        help="Path to local LLaMA model directory",
+    )
     parser.add_argument("--R1_clusters", type=int, default=32)
     parser.add_argument("--R2_clusters", type=int, default=4)
     parser.add_argument("--R3_clusters", type=int, default=4)
@@ -244,31 +250,41 @@ def main():
         lm.model.eval()
     elif "llama3" in args.net:
         size = args.net.split('-')[1]
-        args.model = f"meta-llama/Meta-Llama-3-{size.upper()}"
-        if not os.path.exists(f"{args.cache_dir}/llama3/"):
-            os.makedirs(f"{args.cache_dir}/llama3/")
-        args.cache_dir = f"{args.cache_dir}/llama3/{size}"
-        print(args.cache_dir)
-        cache_file = f"{args.cache_dir}/torch_model.pth"
-        if os.path.exists(cache_file):
+        if args.model_path is not None:
+            args.model = args.model_path
+            cache_file = None
+        else:
+            args.model = f"meta-llama/Meta-Llama-3-{size.upper()}"
+            if not os.path.exists(f"{args.cache_dir}/llama3/"):
+                os.makedirs(f"{args.cache_dir}/llama3/")
+            args.cache_dir = f"{args.cache_dir}/llama3/{size}"
+            print(args.cache_dir)
+            cache_file = f"{args.cache_dir}/torch_model.pth"
+        if cache_file and os.path.exists(cache_file):
             lm = torch.load(cache_file)
         else:
             lm = LlamaClass(args)
-            torch.save(lm, cache_file)
+            if cache_file:
+                torch.save(lm, cache_file)
         lm.model.eval()
     elif "llama" in args.net:
         size = args.net.split('-')[1]
-        args.model = f"meta-llama/Llama-2-{size}-hf"
-        if not os.path.exists(f"{args.cache_dir}/llama/"):
-            os.makedirs(f"{args.cache_dir}/llama/")
-        args.cache_dir = f"{args.cache_dir}/llama/{size}"
-        print(args.cache_dir)
-        cache_file = f"{args.cache_dir}/torch_model.pth"
-        if os.path.exists(cache_file):
+        if args.model_path is not None:
+            args.model = args.model_path
+            cache_file = None
+        else:
+            args.model = f"meta-llama/Llama-2-{size}-hf"
+            if not os.path.exists(f"{args.cache_dir}/llama/"):
+                os.makedirs(f"{args.cache_dir}/llama/")
+            args.cache_dir = f"{args.cache_dir}/llama/{size}"
+            print(args.cache_dir)
+            cache_file = f"{args.cache_dir}/torch_model.pth"
+        if cache_file and os.path.exists(cache_file):
             lm = torch.load(cache_file)
         else:
             lm = LlamaClass(args)
-            torch.save(lm, cache_file)
+            if cache_file:
+                torch.save(lm, cache_file)
         lm.model.eval()
     else:
         raise NotImplementedError

--- a/models/llama.py
+++ b/models/llama.py
@@ -1,3 +1,4 @@
+import os
 import torch
 from .models_utils import BaseLM, find_layers
 from transformers import LlamaForCausalLM, AutoTokenizer
@@ -14,14 +15,19 @@ class LlamaClass(BaseLM):
         self.model_name = args.model
         self.batch_size_per_gpu = args.batch_size
 
+        model_kwargs = {"torch_dtype": "auto"}
+        tokenizer_kwargs = {"use_fast": False}
+        if args.cache_dir and not os.path.isdir(self.model_name):
+            model_kwargs["cache_dir"] = args.cache_dir
+            tokenizer_kwargs["cache_dir"] = args.cache_dir
         self.model = LlamaForCausalLM.from_pretrained(
-            self.model_name, cache_dir=args.cache_dir, torch_dtype="auto"
+            self.model_name, **model_kwargs
         )
         self.seqlen = self.model.config.max_position_embeddings
         self.model.eval()
 
         self.tokenizer = AutoTokenizer.from_pretrained(
-            self.model_name, cache_dir=args.cache_dir, use_fast=False
+            self.model_name, **tokenizer_kwargs
         )
         self.vocab_size = self.tokenizer.vocab_size
         print("Llama vocab size: ", self.vocab_size)


### PR DESCRIPTION
## Summary
- enable specifying a local LLaMA model directory via `--model_path`
- conditionally skip remote caching and cache file creation when using a local path
- load LLaMA tokenizer/model without `cache_dir` when a local path is supplied

## Testing
- `python -m py_compile models/llama.py main.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'sacrebleu', numpy, etc)*
- `pip install numpy sacrebleu tqdm openai omegaconf` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68c7ddbb2fc48332a3fe9f678150c00c