### PR TITLE
Add option to limit LLaMA layers for debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ To quantize larger network please use `--multigpu`:
 python main.py opt-66b --wbits 4 --abits 4 --only_quant_kv --eval_ppl --tasks lambada_openai,piqa,arc_easy,arc_challenge,openbookqa,boolq --multigpu
 ```
 
+For quick debugging of LLaMA models, you can load only the first `N` hidden layers:
+```
+python main.py llama-7b --hidden_layer_num 2 --eval_ppl
+```
+
 ### Results
 
 Perplexity

--- a/main.py
+++ b/main.py
@@ -224,6 +224,12 @@ def main():
     parser.add_argument(
         "--multigpu", action="store_true", help="at eval, map model to multiple gpus"
     )
+    parser.add_argument(
+        "--hidden_layer_num",
+        type=int,
+        default=None,
+        help="Number of LLaMA hidden layers to use for quick debugging",
+    )
 
     args = parser.parse_args()
     args.batch_size = 1  # BS=1 is used for zeroShot tasks!
@@ -266,6 +272,8 @@ def main():
             lm = LlamaClass(args)
             if cache_file:
                 torch.save(lm, cache_file)
+        if args.hidden_layer_num:
+            lm.truncate_hidden_layers(args.hidden_layer_num)
         lm.model.eval()
     elif "llama" in args.net:
         size = args.net.split('-')[1]
@@ -285,6 +293,8 @@ def main():
             lm = LlamaClass(args)
             if cache_file:
                 torch.save(lm, cache_file)
+        if args.hidden_layer_num:
+            lm.truncate_hidden_layers(args.hidden_layer_num)
         lm.model.eval()
     else:
         raise NotImplementedError


### PR DESCRIPTION
## Summary
- allow specifying `--hidden_layer_num` to load only a subset of LLaMA layers
- add `truncate_hidden_layers` helper in `LlamaClass`
- document debug flag in README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sacrebleu')*

------
https://chatgpt.com/codex/tasks/task_e_68c7e13bbb708332b74ff520c19e17b3