### PR TITLE
Limit LLaMA layers at load time to reduce memory

### DIFF
--- a/main.py
+++ b/main.py
@@ -272,8 +272,6 @@ def main():
             lm = LlamaClass(args)
             if cache_file:
                 torch.save(lm, cache_file)
-        if args.hidden_layer_num:
-            lm.truncate_hidden_layers(args.hidden_layer_num)
         lm.model.eval()
     elif "llama" in args.net:
         size = args.net.split('-')[1]
@@ -293,8 +291,6 @@ def main():
             lm = LlamaClass(args)
             if cache_file:
                 torch.save(lm, cache_file)
-        if args.hidden_layer_num:
-            lm.truncate_hidden_layers(args.hidden_layer_num)
         lm.model.eval()
     else:
         raise NotImplementedError


### PR DESCRIPTION
## Summary
- load LLaMA models directly with specified `hidden_layer_num` so extra layers aren't instantiated
- load weights in float16 with low CPU memory usage to lower overall memory footprint
- drop redundant post-load truncation in main

## Testing
- `python -m py_compile models/llama.py main.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sacrebleu')*

------
https://chatgpt.com/codex/tasks/task_e_68c814ecdfb483329387baaa65450b2e